### PR TITLE
nouveau_xv: fix missing include of extinit.h

### DIFF
--- a/src/nouveau_xv.c
+++ b/src/nouveau_xv.c
@@ -25,6 +25,9 @@
 #include "config.h"
 #endif
 
+#include <xorg-server.h>
+#include <extinit.h>
+
 #ifdef __SSE2__
 #include <immintrin.h>
 #endif


### PR DESCRIPTION
> nouveau_xv.c: In function 'NVSetupOverlayVideo':
> nouveau_xv.c:1973:14: error: 'noCompositeExtension' undeclared (first use in this function)
>  1973 |         if (!noCompositeExtension) {