### PR TITLE
fix NULL pScrn passed to NVEnterVT/NVLeaveVT

### DIFF
--- a/src/nv_driver.c
+++ b/src/nv_driver.c
@@ -607,7 +607,7 @@ NVCreateScreenResources(ScreenPtr pScreen)
 	pScreen->CreateScreenResources = NVCreateScreenResources;
 
 	drmmode_fbcon_copy(pScreen);
-	if (!NVEnterVT(NULL))
+	if (!NVEnterVT(pScrn))
 		return FALSE;
 
 	if (pNv->AccelMethod == EXA) {
@@ -641,7 +641,7 @@ NVCloseScreen(ScreenPtr pScreen)
 	nouveau_copy_fini(pScreen);
 
 	if (pScrn->vtSema) {
-		NVLeaveVT(NULL);
+		NVLeaveVT(pScrn);
 		pScrn->vtSema = FALSE;
 	}
 


### PR DESCRIPTION
The old VT_FUNC_ARGS(0) compat macro actually expanded to pScrn, not to a literal 0. When b2c20c1 dropped the compat macros, these calls were mistakenly rewritten to pass NULL instead of pScrn, causing a crash on NVEnterVT/NVLeaveVT.