### PR TITLE
replace deprecated min/max macros by MIN/MAX

### DIFF
--- a/src/nouveau_dri2.c
+++ b/src/nouveau_dri2.c
@@ -890,7 +890,7 @@ nouveau_dri2_schedule_swap(ClientPtr client, DrawablePtr draw,
 		/* Request a vblank event one frame before the target */
 		ret = nouveau_wait_vblank(draw, DRM_VBLANK_ABSOLUTE |
 					  DRM_VBLANK_EVENT,
-					  max(current_msc, *target_msc - 1),
+					  MAX(current_msc, *target_msc - 1),
 					  &expect_msc, NULL, s);
 		if (ret)
 			goto fail;
@@ -949,7 +949,7 @@ nouveau_dri2_schedule_wait(ClientPtr client, DrawablePtr draw,
 	/* Request a vblank event */
 	ret = nouveau_wait_vblank(draw, DRM_VBLANK_ABSOLUTE |
 				  DRM_VBLANK_EVENT,
-				  max(current_msc, target_msc),
+				  MAX(current_msc, target_msc),
 				  NULL, NULL, s);
 	if (ret)
 		goto fail;

--- a/src/nouveau_local.h
+++ b/src/nouveau_local.h
@@ -45,6 +45,13 @@
 
 #define NOUVEAU_ALIGN(x,bytes) (((x) + ((bytes) - 1)) & ~((bytes) - 1))
 
+#ifndef MAX
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+#ifndef MIN
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+
 #define NV50_TILE_PITCH(m) (64 << ((m) & 0xf))
 #define NV50_TILE_HEIGHT(m) (4 << ((m) >> 4))
 #define NVC0_TILE_PITCH(m) (64 << ((m) & 0xf))

--- a/src/nv_accel_common.c
+++ b/src/nv_accel_common.c
@@ -92,7 +92,7 @@ nouveau_allocate_surface(ScrnInfoPtr scrn, int width, int height, int bpp,
 			height = NOUVEAU_ALIGN(height,
 				 NV50_TILE_HEIGHT(cfg.nv50.tile_mode));
 		} else {
-			int pitch_align = max(
+			int pitch_align = MAX(
 				pNv->dev->chipset >= 0x40 ? 1024 : 256,
 				round_down_pow2(*pitch / 4));
 

--- a/src/nv_driver.c
+++ b/src/nv_driver.c
@@ -207,7 +207,7 @@ NVIdentify(int flags)
     family = NVKnownFamilies;
     while(family->name && family->chipset)
     {
-        maxLen = max(maxLen, strlen(family->name));
+        maxLen = MAX(maxLen, strlen(family->name));
         family++;
     }
 

--- a/src/nv_shadow.c
+++ b/src/nv_shadow.c
@@ -25,9 +25,6 @@
 #include "shadowfb.h"
 #include "servermd.h"
 
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
-
 void
 NVRefreshArea(ScrnInfoPtr pScrn, int num, BoxPtr pbox)
 {


### PR DESCRIPTION
These xserver's public macros are being deprecated in favor of private ones. The drivers need to declare them locally.

Reference: https://github.com/X11Libre/xserver/pull/1490
Fixes https://github.com/X11Libre/xf86-video-nouveau/issues/16