### PR TITLE
nv_driver: fix segfault on startup

### DIFF
--- a/src/nv_driver.c
+++ b/src/nv_driver.c
@@ -607,7 +607,7 @@ NVCreateScreenResources(ScreenPtr pScreen)
 	pScreen->CreateScreenResources = NVCreateScreenResources;
 
 	drmmode_fbcon_copy(pScreen);
-	if (!NVEnterVT(NULL))
+	if (!NVEnterVT(pScrn))
 		return FALSE;
 
 	if (pNv->AccelMethod == EXA) {


### PR DESCRIPTION
NVCreateScreenResources() is calling NVEnterVT() - the Screen's handler for entering a VT, but passing NULL instead of the required ScrnInfoPtr, thus leading to crash when it's trying to retrieve it's driverPrivate data.

See: https://github.com/X11Libre/xserver/issues/3093
See: https://github.com/X11Libre/xserver/issues/3144
